### PR TITLE
The wireframe gizmos now update in edit mode, to give you a preview

### DIFF
--- a/FastIK/Assets/FastIK/Scripts/FastIK/FastIKFabric.cs
+++ b/FastIK/Assets/FastIK/Scripts/FastIK/FastIKFabric.cs
@@ -8,6 +8,7 @@ namespace DitzelGames.FastIK
     /// <summary>
     /// Fabrik IK Solver
     /// </summary>
+    [ExecuteInEditMode]
     public class FastIKFabric : MonoBehaviour
     {
         /// <summary>
@@ -49,12 +50,6 @@ namespace DitzelGames.FastIK
         protected Transform Root;
 
 
-        // Start is called before the first frame update
-        void Awake()
-        {
-            Init();
-        }
-
         void Init()
         {
             //initial array
@@ -74,11 +69,6 @@ namespace DitzelGames.FastIK
             }
 
             //init target
-            if (Target == null)
-            {
-                Target = new GameObject(gameObject.name + " Target").transform;
-                SetPositionRootSpace(Target, GetPositionRootSpace(transform));
-            }
             StartRotationTarget = GetRotationRootSpace(Target);
 
 
@@ -121,7 +111,7 @@ namespace DitzelGames.FastIK
             if (Target == null)
                 return;
 
-            if (BonesLength.Length != ChainLength)
+            if (BonesLength == null || BonesLength.Length != ChainLength)
                 Init();
 
             //Fabric
@@ -187,14 +177,17 @@ namespace DitzelGames.FastIK
                 }
             }
 
-            //set position & rotation
-            for (int i = 0; i < Positions.Length; i++)
+            //set position & rotation(but only in play mode)
+            if (Application.isPlaying)
             {
-                if (i == Positions.Length - 1)
-                    SetRotationRootSpace(Bones[i], Quaternion.Inverse(targetRotation) * StartRotationTarget * Quaternion.Inverse(StartRotationBone[i]));
-                else
-                    SetRotationRootSpace(Bones[i], Quaternion.FromToRotation(StartDirectionSucc[i], Positions[i + 1] - Positions[i]) * Quaternion.Inverse(StartRotationBone[i]));
-                SetPositionRootSpace(Bones[i], Positions[i]);
+                for (int i = 0; i < Positions.Length; i++)
+                {
+                    if (i == Positions.Length - 1)
+                        SetRotationRootSpace(Bones[i], Quaternion.Inverse(targetRotation) * StartRotationTarget * Quaternion.Inverse(StartRotationBone[i]));
+                    else
+                        SetRotationRootSpace(Bones[i], Quaternion.FromToRotation(StartDirectionSucc[i], Positions[i + 1] - Positions[i]) * Quaternion.Inverse(StartRotationBone[i]));
+                    SetPositionRootSpace(Bones[i], Positions[i]);
+                }
             }
         }
 
@@ -235,16 +228,29 @@ namespace DitzelGames.FastIK
         {
 #if UNITY_EDITOR
             var current = this.transform;
-            for (int i = 0; i < ChainLength && current != null && current.parent != null; i++)
+            Vector3 origin = Root.position;
+            for (int i = 0; i < Positions.Length - 1; i++)
             {
-                var scale = Vector3.Distance(current.position, current.parent.position) * 0.1f;
-                Handles.matrix = Matrix4x4.TRS(current.position, Quaternion.FromToRotation(Vector3.up, current.parent.position - current.position), new Vector3(scale, Vector3.Distance(current.parent.position, current.position), scale));
+                Vector3 currentPoint = origin + (Vector3)(Root.worldToLocalMatrix * Positions[i]);
+                Vector3 nextPoint    = origin + (Vector3)(Root.worldToLocalMatrix * Positions[i + 1]);
+
+                float dist = Vector3.Distance(currentPoint, nextPoint);
+                float scale = dist * 0.1f;
+                var rot = Quaternion.FromToRotation(
+                    Vector3.up,
+                    nextPoint - currentPoint
+                );
+                Handles.matrix = Matrix4x4.TRS(
+                    currentPoint,
+                    rot,
+                    new Vector3(scale, dist, scale)
+                );
                 Handles.color = Color.green;
                 Handles.DrawWireCube(Vector3.up * 0.5f, Vector3.one);
-                current = current.parent;
             }
-#endif
+
         }
+#endif
 
     }
 }

--- a/FastIK/Assets/FastIK/Scripts/FastIK/FastIKFabric.cs
+++ b/FastIK/Assets/FastIK/Scripts/FastIK/FastIKFabric.cs
@@ -231,8 +231,8 @@ namespace DitzelGames.FastIK
             Vector3 origin = Root.position;
             for (int i = 0; i < Positions.Length - 1; i++)
             {
-                Vector3 currentPoint = origin + (Vector3)(Root.worldToLocalMatrix * Positions[i]);
-                Vector3 nextPoint    = origin + (Vector3)(Root.worldToLocalMatrix * Positions[i + 1]);
+                Vector3 currentPoint = origin + (Vector3)(Root.localToWorldMatrix * Positions[i]);
+                Vector3 nextPoint    = origin + (Vector3)(Root.localToWorldMatrix * Positions[i + 1]);
 
                 float dist = Vector3.Distance(currentPoint, nextPoint);
                 float scale = dist * 0.1f;


### PR DESCRIPTION
This way, you don't need to keep switching to play-mode when creating an animation that moves an IK target.

To achieve this, I made the script execute in edit mode, except for the part that applies the transformations to the GameObjects.  I then rewrote OnDrawGizmos() so that it looks at the Positions[] array, instead of the GameObject transforms.

I also made some other changes to make it behave nicer in edit mode:
* It now calls Init() in LateUpdate() when BonesLength is null, in case the script was disabled and missed its Awake() event.

* Init() no longer creates a new Target object if Target is null.  This avoids cluttering the scene(or worse, the prefab) with tons of GameObjects before the user has had a chance to assign the target.